### PR TITLE
fix(chat): add baseline alignment for display name

### DIFF
--- a/src/app/routes/chat/chat.component.css
+++ b/src/app/routes/chat/chat.component.css
@@ -41,6 +41,7 @@ p {
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
+  align-self: baseline;
 }
 .message-wrap {
   display: inline-block;


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/1770529/119726858-481bc880-be7a-11eb-8fca-360c28af6b75.png)

after:
![image](https://user-images.githubusercontent.com/1770529/119726875-4eaa4000-be7a-11eb-8629-9c05a72227b7.png)
